### PR TITLE
Adding a different color to git ignored

### DIFF
--- a/themes/codesandbox-dark.json
+++ b/themes/codesandbox-dark.json
@@ -105,7 +105,8 @@
 
     "gitDecoration.deletedResourceForeground": "#C54444",
     "gitDecoration.untrackedResourceForeground": "#9FE7A0",
-    "gitDecoration.conflictingResourceForeground": "#ED6C6C"
+    "gitDecoration.conflictingResourceForeground": "#ED6C6C",
+    "gitDecoration.ignoredResourceForeground": "#585858"
   },
   "tokenColors": [
     {


### PR DESCRIPTION
The theme needs a color to differentiate git ignored folders and files. It is a minimal addition for this purpose.