### PR TITLE
Use entity.name.function

### DIFF
--- a/themes/codesandbox-dark.json
+++ b/themes/codesandbox-dark.json
@@ -276,13 +276,8 @@
       "settings": { "foreground": "#ffffff" }
     },
     {
-      "name": "meta.field.declaration entity.name.function",
-      "scope": ["meta.field.declaration entity.name.function"],
-      "settings": { "foreground": "#CDF861" }
-    },
-    {
-      "name": "meta.definition.method entity.name.function",
-      "scope": ["meta.definition.method entity.name.function"],
+      "name": "entity.name.function",
+      "scope": ["entity.name.function"],
       "settings": { "foreground": "#CDF861" }
     },
     {


### PR DESCRIPTION
Using `entity.name.function` you get the same color for functions
-  declartion lines 21, 28,35
- methods lines: 24, 35
- passing a function as prop will so get colored as function `passFunction` prop is green


Left is before, Right is with changes
<img width="1805" alt="Screen Shot 2022-06-29 at 5 51 06 PM" src="https://user-images.githubusercontent.com/16880975/176552523-677967e5-2927-4313-91a3-f45e3682348b.png">

