### PR TITLE
fix: attribute name typo

### DIFF
--- a/themes/codesandbox-dark.json
+++ b/themes/codesandbox-dark.json
@@ -28,7 +28,7 @@
     "activityBarBadge.foreground": "#000",
     "activityBarBadge.background": "#edffa5",
     "activityBar.border": "#000",
-    "actibityBar.activeBackground": "#151515",
+    "activityBar.activeBackground": "#151515",
 
     "sideBar.background": "#000",
     "sideBar.foreground": "#999",


### PR DESCRIPTION
### Description
This pull request addresses an issue where the activity bar's background wouldn't change, it turned out to be a typo in the codesandbox-dark.json file.


### Changes:
- Changed "actibityBar.activeBackground" to "activityBar.activeBackground" in codesandbox-dark.json